### PR TITLE
feat[automod]: add user reputation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.prisma]
+indent_size = 2

--- a/prisma/migrations/20220527065949_init/migration.sql
+++ b/prisma/migrations/20220527065949_init/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "Reputation" (
+    "guildId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "reputation" DECIMAL(65,30) NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Reputation_guildId_userId_key" ON "Reputation"("guildId", "userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,3 +16,10 @@ model LogConfig {
   userFilterChannelId String?
   userChangesChannelId String?
 }
+
+model Reputation {
+  guildId String
+  userId String
+  reputation Decimal
+  @@unique([guildId, userId])
+}

--- a/src/modules/automod/UserReputation.ts
+++ b/src/modules/automod/UserReputation.ts
@@ -1,0 +1,114 @@
+import { PrismaClient, Reputation } from '@prisma/client';
+import { Decimal } from '@prisma/client/runtime';
+import { GuildMember, User } from 'discord.js';
+import ExpiryMap from 'expiry-map';
+
+const prisma = new PrismaClient();
+
+function clamp(value: number, min: number, max: number) {
+    value = value < min ? min : value;
+    return value > max ? max : value;
+}
+
+type ReputationLevel = 'DANGEROUS' | 'RESTRICTED' | 'AT RISK' | 'QUESTIONABLE' | 'DEFAULT' | 'LOW RISK' | 'SLIGHTLY TRUSTED' | 'TRUSTED' | 'VERY TRUSTED' | 'SUPERUSER';
+
+class ReputationView {
+    readonly value: number;
+    readonly level: ReputationLevel;
+    constructor(value: number, isSuperUser: boolean) {
+        this.value = clamp(value, -5, 5);
+
+        if(isSuperUser) {
+            this.level = 'SUPERUSER';
+            return;
+        }
+
+        if(value <= -4)
+            this.level = 'DANGEROUS';
+        else if(value > -4 && value <= -3)
+            this.level = 'RESTRICTED';
+        else if(value > -3 && value <= -2)
+            this.level = 'AT RISK';
+        else if(value > -2 && value <= -1)
+            this.level = 'QUESTIONABLE';
+        else if (value > -1 && value < 1)
+            this.level = 'DEFAULT';
+        else if(value >= 1 && value < 2)
+            this.level = `LOW RISK`;
+        else if(value >= 2 && value < 3)
+            this.level = 'SLIGHTLY TRUSTED';
+        else if(value >= 3 && value < 4)
+            this.level = 'TRUSTED';
+        else if(value >= 4)
+            this.level = 'VERY TRUSTED';
+        else
+            this.level = 'DEFAULT';
+    }
+}
+
+export default class {
+    private static reputationCache: ExpiryMap<string, Reputation> = new ExpiryMap(15 * 60 * 1000);
+
+    private static getKey(member: GuildMember): string {
+        return `${member.guild.id}:${member.id}`;
+    }
+
+    private static async createDefaultReputation(member: GuildMember): Promise<Reputation> {
+        const defaultRep = 0;
+        const data = await prisma.reputation.create({
+            data: {
+                guildId: member.guild.id,
+                userId: member.id,
+                reputation: defaultRep
+            }
+        });
+
+        this.reputationCache.set(this.getKey(member), data);
+
+        return data;
+    }
+
+    /**
+     * Fetches a particular member's reputation in their current guild. If no reputation data exist, they are given
+     * a default reputation value of `0`
+     * @param member The member to fetch the reputation of
+     * @returns The member's reputation
+     */
+    static async fetchReputation(member: GuildMember): Promise<Reputation> {
+        const data = this.reputationCache.get(this.getKey(member)) ?? await prisma.reputation.findUnique({
+            where: {
+                guildId_userId: {
+                    guildId: member.guild.id,
+                    userId: member.id
+                }
+            }
+        });
+
+        return data != null ? data : await this.createDefaultReputation(member);
+    }
+
+    /**
+     * Modifies the reputation of a given member
+     * @param member The member to modify the reputation of
+     * @param offset The number to add to the reputation. Use negative numbers to subtract reputation
+     */
+    static async modifyReputation(member: GuildMember, offset: number) {
+        let data = await this.fetchReputation(member);
+
+        data.reputation = new Decimal(clamp(data.reputation.toNumber() + offset, -5, 5));
+
+        this.reputationCache.set(this.getKey(member), data);
+
+        await prisma.reputation.update({
+            where: {
+                guildId_userId: {
+                    guildId: member.guild.id,
+                    userId: member.id
+                }
+            },
+            data: {
+                reputation: data.reputation
+            }
+        });
+    }
+}

--- a/src/modules/logging/LoggingModule.ts
+++ b/src/modules/logging/LoggingModule.ts
@@ -39,7 +39,7 @@ export default class LoggingModule {
      * @returns The configuration
      */
     static async fetchLogConfiguration(guild: Guild): Promise<LogConfig> {
-        let data = this.configCache.get(guild.id) ?? await prisma.logConfig.findUnique({
+        const data = this.configCache.get(guild.id) ?? await prisma.logConfig.findUnique({
             where: {
                 guildId: guild.id
             }


### PR DESCRIPTION
This PR adds user reputation handling. By default, messages not caught by the anti-spam earn the user `0.035` reputation. Each time a user has their message deleted from the anti-spam, the user loses `0.2` reputation, with an additional `0.3` lost if the user gets put in time out.