### PR TITLE
fix[i18n]: localize name sanitizer logs

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -27,6 +27,24 @@
                         }
                     }
                 }
+            },
+            "nameSanitizer": {
+                "filtered": {
+                    "title": "Nickname Filtered",
+                    "description": "{{- userMention}} had their nickname filtered",
+                    "reason": "Sanitizing Nickname",
+                    "fields": {
+                        "before": {
+                            "name": "Before"
+                        },
+                        "after": {
+                            "name": "After"
+                        },
+                        "reason": {
+                            "name": "Reason"
+                        }
+                    }
+                }
             }
         },
         "joins": {

--- a/src/modules/automod/NameSanitizer.ts
+++ b/src/modules/automod/NameSanitizer.ts
@@ -54,20 +54,20 @@ export default class NameSanitizerModule {
                             i18next.t('logging.automod.nameSanitizer.filtered.description', {
                                 lng: lng,
                                 userMention: member.toString()
-                        }))
+                            }))
                         .setColor(0xfee75c)
                         .addFields(
                             {
-                                "name": i18next.t('logging.automod.nameSanitizer.filtered.fields.before.name', { lng: lng }),
-                                "value": name,
+                                'name': i18next.t('logging.automod.nameSanitizer.filtered.fields.before.name', { lng: lng }),
+                                'value': name,
                             },
                             {
-                                "name": i18next.t('logging.automod.nameSanitizer.filtered.fields.after.name', { lng: lng }),
-                                "value": sanitized
+                                'name': i18next.t('logging.automod.nameSanitizer.filtered.fields.after.name', { lng: lng }),
+                                'value': sanitized
                             },
                             {
-                                "name": i18next.t('logging.automod.nameSanitizer.filtered.fields.reason.name', { lng: lng }),
-                                "value": reason
+                                'name': i18next.t('logging.automod.nameSanitizer.filtered.fields.reason.name', { lng: lng }),
+                                'value': reason
                             }
                         )
                 ],

--- a/src/modules/automod/NameSanitizer.ts
+++ b/src/modules/automod/NameSanitizer.ts
@@ -3,6 +3,7 @@ import replacements from '../../../data/fancy_replacements.json';
 import { canModerate } from '../../util/checks';
 import { getEmbedWithTarget } from '../../util/embed';
 import LoggingModule from '../logging/LoggingModule';
+import i18next from 'i18next';
 
 const fancy_replacements = new Map<string, string>();
 for (const pair of Object.entries(replacements)) {
@@ -33,24 +34,42 @@ export default class NameSanitizerModule {
         if (channel == null || !canModerate(member.guild.me, member)) return;
 
         const name = member.displayName;
+        const lng = member.guild.preferredLocale;
         let sanitized = this.cleanFancyText(name);
         if (name != sanitized && this.canOverwriteName(member)) {
+
+            // TODO: Default fallback nickname should be configurable per-guild
+            // We won't localize this as a result
             if (sanitized.trim() === '') sanitized = 'Nickname';
 
-
-            const reason = 'Sanitizing Nickname';
+            const reason = i18next.t('logging.automod.nameSanitizer.filtered.reason', { lng: lng });
             await member.edit({ nick: sanitized }, reason);
 
             await channel.send({
                 content: member.id,
                 embeds: [
-                    getEmbedWithTarget(member.user)
-                        .setTitle('Nickname Filtered')
-                        .setDescription(member.toString() + ' had their display name filtered')
+                    getEmbedWithTarget(member.user, lng)
+                        .setTitle(i18next.t('logging.automod.nameSanitizer.filtered.title', { lng: lng }))
+                        .setDescription(
+                            i18next.t('logging.automod.nameSanitizer.filtered.description', {
+                                lng: lng,
+                                userMention: member.toString()
+                        }))
                         .setColor(0xfee75c)
-                        .addField('Before', name)
-                        .addField('After', sanitized)
-                        .addField('Reason', reason),
+                        .addFields(
+                            {
+                                "name": i18next.t('logging.automod.nameSanitizer.filtered.fields.before.name', { lng: lng }),
+                                "value": name,
+                            },
+                            {
+                                "name": i18next.t('logging.automod.nameSanitizer.filtered.fields.after.name', { lng: lng }),
+                                "value": sanitized
+                            },
+                            {
+                                "name": i18next.t('logging.automod.nameSanitizer.filtered.fields.reason.name', { lng: lng }),
+                                "value": reason
+                            }
+                        )
                 ],
             });
         }


### PR DESCRIPTION
This PR (properly) fixes an issue where the name sanitizer is not properly localized, causing the bot to not start

Relates to: #21 