### PR TITLE
feat: add support for slash command handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn.lock
 
 # Ignore Bot Configuration
 config.json
+
+# Ignore warden's cache of slash command data
+warden.commands.cache

--- a/config.example.json
+++ b/config.example.json
@@ -1,3 +1,5 @@
 {
-    "token": "YOUR BOT TOKEN GOES HERE"
+    "token": "YOUR BOT TOKEN GOES HERE",
+    "clientId": "YOUR BOT CLIENT ID GOES HERE",
+    "ownerId": "YOUR DISCORD USER ID GOES HERE"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
+        "@discordjs/builders": "^0.15.0",
         "@prisma/client": "^3.14.0",
         "discord.js": "^13.8.0",
         "expiry-map": "^2.0.0",
@@ -36,9 +37,9 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.14.0.tgz",
-      "integrity": "sha512-+fqLIqa9wN3R+kvlld8sgG0nt04BAZxdCDP4t2qZ9TJsquLWA+xMtT8Waibb3d4li4AQS+IOfjiHAznv/dhHgQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.15.0.tgz",
+      "integrity": "sha512-w1UfCPzx2iKycn6qh/f0c+PcDpcTHzHr7TXALXu/a4gKHGamiSg3lP8GhYswweSJk/Q5cbFLHZUsnoY3MVKNAg==",
       "dependencies": {
         "@sapphire/shapeshift": "^3.1.0",
         "@sindresorhus/is": "^4.6.0",
@@ -700,6 +701,22 @@
       "engines": {
         "node": ">=16.6.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/discord.js/node_modules/@discordjs/builders": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.14.0.tgz",
+      "integrity": "sha512-+fqLIqa9wN3R+kvlld8sgG0nt04BAZxdCDP4t2qZ9TJsquLWA+xMtT8Waibb3d4li4AQS+IOfjiHAznv/dhHgQ==",
+      "dependencies": {
+        "@sapphire/shapeshift": "^3.1.0",
+        "@sindresorhus/is": "^4.6.0",
+        "discord-api-types": "^0.33.3",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/doctrine": {
@@ -1837,9 +1854,9 @@
       }
     },
     "@discordjs/builders": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.14.0.tgz",
-      "integrity": "sha512-+fqLIqa9wN3R+kvlld8sgG0nt04BAZxdCDP4t2qZ9TJsquLWA+xMtT8Waibb3d4li4AQS+IOfjiHAznv/dhHgQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.15.0.tgz",
+      "integrity": "sha512-w1UfCPzx2iKycn6qh/f0c+PcDpcTHzHr7TXALXu/a4gKHGamiSg3lP8GhYswweSJk/Q5cbFLHZUsnoY3MVKNAg==",
       "requires": {
         "@sapphire/shapeshift": "^3.1.0",
         "@sindresorhus/is": "^4.6.0",
@@ -2296,6 +2313,21 @@
         "form-data": "^4.0.0",
         "node-fetch": "^2.6.1",
         "ws": "^8.7.0"
+      },
+      "dependencies": {
+        "@discordjs/builders": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.14.0.tgz",
+          "integrity": "sha512-+fqLIqa9wN3R+kvlld8sgG0nt04BAZxdCDP4t2qZ9TJsquLWA+xMtT8Waibb3d4li4AQS+IOfjiHAznv/dhHgQ==",
+          "requires": {
+            "@sapphire/shapeshift": "^3.1.0",
+            "@sindresorhus/is": "^4.6.0",
+            "discord-api-types": "^0.33.3",
+            "fast-deep-equal": "^3.1.3",
+            "ts-mixer": "^6.0.1",
+            "tslib": "^2.4.0"
+          }
+        }
       }
     },
     "doctrine": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@discordjs/builders": "^0.15.0",
+        "@discordjs/rest": "^0.5.0",
         "@prisma/client": "^3.14.0",
+        "discord-api-types": "^0.34.0",
         "discord.js": "^13.8.0",
         "expiry-map": "^2.0.0",
         "i18next": "^21.8.4",
@@ -52,6 +54,11 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
+    },
     "node_modules/@discordjs/collection": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
@@ -59,6 +66,27 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-0.5.0.tgz",
+      "integrity": "sha512-S4E1YNz1UxgUfMPpMeqzPPkCfXE877zOsvKM5WEmwIhcpz1PQV7lzqlEOuz194UuwOJLLjQFBgQELnQfCX9UfA==",
+      "dependencies": {
+        "@discordjs/collection": "^0.7.0",
+        "@sapphire/async-queue": "^1.3.1",
+        "@sapphire/snowflake": "^3.2.2",
+        "discord-api-types": "^0.33.3",
+        "tslib": "^2.4.0",
+        "undici": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/discord-api-types": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.0",
@@ -182,6 +210,15 @@
       "integrity": "sha512-asNgE5Ooil2/oGIAj6vZMoUc2ZFED0TGYD7jwvZsjHPQZBEh9ITj94ca4bCgiCR1s2ER/UjzykH+5wE3ebVZnQ==",
       "engines": {
         "node": ">=v15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.2.2.tgz",
+      "integrity": "sha512-ula2O0kpSZtX9rKXNeQMrHwNd7E4jPDJYUXmEGTFdMRfyfMw+FPyh04oKMjAiDuOi64bYgVkOV3MjK+loImFhQ==",
+      "engines": {
+        "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
@@ -679,9 +716,9 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
-      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.34.0.tgz",
+      "integrity": "sha512-xwlhwiLZ11+8+ou1JlPOLJkwpu8qklm+aUm9JF06YC59fSo4CD7gQqsbUBxqevqheLx+WhRgJOHjDbjI0Q+Ecw=="
     },
     "node_modules/discord.js": {
       "version": "13.8.0",
@@ -718,6 +755,11 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/discord.js/node_modules/discord-api-types": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -1758,6 +1800,14 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw==",
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -1864,12 +1914,39 @@
         "fast-deep-equal": "^3.1.3",
         "ts-mixer": "^6.0.1",
         "tslib": "^2.4.0"
+      },
+      "dependencies": {
+        "discord-api-types": {
+          "version": "0.33.5",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+          "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
+        }
       }
     },
     "@discordjs/collection": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.7.0.tgz",
       "integrity": "sha512-R5i8Wb8kIcBAFEPLLf7LVBQKBDYUL+ekb23sOgpkpyGT+V4P7V83wTxcsqmX+PbqHt4cEHn053uMWfRqh/Z/nA=="
+    },
+    "@discordjs/rest": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-0.5.0.tgz",
+      "integrity": "sha512-S4E1YNz1UxgUfMPpMeqzPPkCfXE877zOsvKM5WEmwIhcpz1PQV7lzqlEOuz194UuwOJLLjQFBgQELnQfCX9UfA==",
+      "requires": {
+        "@discordjs/collection": "^0.7.0",
+        "@sapphire/async-queue": "^1.3.1",
+        "@sapphire/snowflake": "^3.2.2",
+        "discord-api-types": "^0.33.3",
+        "tslib": "^2.4.0",
+        "undici": "^5.4.0"
+      },
+      "dependencies": {
+        "discord-api-types": {
+          "version": "0.33.5",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+          "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
+        }
+      }
     },
     "@eslint/eslintrc": {
       "version": "1.3.0",
@@ -1959,6 +2036,11 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.2.0.tgz",
       "integrity": "sha512-asNgE5Ooil2/oGIAj6vZMoUc2ZFED0TGYD7jwvZsjHPQZBEh9ITj94ca4bCgiCR1s2ER/UjzykH+5wE3ebVZnQ=="
+    },
+    "@sapphire/snowflake": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.2.2.tgz",
+      "integrity": "sha512-ula2O0kpSZtX9rKXNeQMrHwNd7E4jPDJYUXmEGTFdMRfyfMw+FPyh04oKMjAiDuOi64bYgVkOV3MjK+loImFhQ=="
     },
     "@sindresorhus/is": {
       "version": "4.6.0",
@@ -2295,9 +2377,9 @@
       }
     },
     "discord-api-types": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
-      "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.34.0.tgz",
+      "integrity": "sha512-xwlhwiLZ11+8+ou1JlPOLJkwpu8qklm+aUm9JF06YC59fSo4CD7gQqsbUBxqevqheLx+WhRgJOHjDbjI0Q+Ecw=="
     },
     "discord.js": {
       "version": "13.8.0",
@@ -2327,6 +2409,11 @@
             "ts-mixer": "^6.0.1",
             "tslib": "^2.4.0"
           }
+        },
+        "discord-api-types": {
+          "version": "0.33.5",
+          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.33.5.tgz",
+          "integrity": "sha512-dvO5M52v7m7Dy96+XUnzXNsQ/0npsYpU6dL205kAtEDueswoz3aU3bh1UMoK4cQmcGtB1YRyLKqp+DXi05lzFg=="
         }
       }
     },
@@ -3068,6 +3155,11 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
       "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
+    },
+    "undici": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.5.1.tgz",
+      "integrity": "sha512-MEvryPLf18HvlCbLSzCW0U00IMftKGI5udnjrQbC5D4P0Hodwffhv+iGfWuJwg16Y/TK11ZFK8i+BPVW2z/eAw=="
     },
     "uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   "homepage": "https://github.com/CheesyGamer77/Warden#readme",
   "dependencies": {
     "@discordjs/builders": "^0.15.0",
+    "@discordjs/rest": "^0.5.0",
     "@prisma/client": "^3.14.0",
+    "discord-api-types": "^0.34.0",
     "discord.js": "^13.8.0",
     "expiry-map": "^2.0.0",
     "i18next": "^21.8.4",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/CheesyGamer77/Warden#readme",
   "dependencies": {
+    "@discordjs/builders": "^0.15.0",
     "@prisma/client": "^3.14.0",
     "discord.js": "^13.8.0",
     "expiry-map": "^2.0.0",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,0 +1,11 @@
+import CommandListener from '../util/commands/CommandListener';
+import PingCommand from './ping';
+
+const listener = new CommandListener(
+    new PingCommand()
+);
+
+export {
+    listener,
+    PingCommand
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -8,4 +8,4 @@ const listener = new CommandListener(
 export {
     listener,
     PingCommand
-}
+};

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,8 +1,5 @@
 import CommandListener from '../util/commands/CommandListener';
-import PingCommand from './ping';
 
-const listener = new CommandListener(
-    new PingCommand()
-);
+const listener = new CommandListener();
 
 export { listener };

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -5,7 +5,4 @@ const listener = new CommandListener(
     new PingCommand()
 );
 
-export {
-    listener,
-    PingCommand
-};
+export { listener };

--- a/src/handlers/guildMemberAdd.ts
+++ b/src/handlers/guildMemberAdd.ts
@@ -1,6 +1,6 @@
 import { GuildMember } from 'discord.js';
 import LoggingModule from '../modules/logging/LoggingModule';
 
-export async function onGuildMemberAdd(member: GuildMember) {
+export default async function onGuildMemberAdd(member: GuildMember) {
     await LoggingModule.logMemberJoined(member);
 }

--- a/src/handlers/guildMemberRemove.ts
+++ b/src/handlers/guildMemberRemove.ts
@@ -1,6 +1,6 @@
 import LoggingModule from '../modules/logging/LoggingModule';
 import { GuildMember, PartialGuildMember } from 'discord.js';
 
-export async function onGuildMemberRemove(member: GuildMember | PartialGuildMember) {
+export default async function onGuildMemberRemove(member: GuildMember | PartialGuildMember) {
     await LoggingModule.logMemberLeft(member);
 }

--- a/src/handlers/guildMemberUpdate.ts
+++ b/src/handlers/guildMemberUpdate.ts
@@ -58,7 +58,7 @@ function getRoleUpdateEmbed(member: GuildMember, roles: Collection<string, Role>
         );
 }
 
-export async function onGuildMemberUpdate(before: GuildMember | PartialGuildMember, after: GuildMember) {
+export default async function onGuildMemberUpdate(before: GuildMember | PartialGuildMember, after: GuildMember) {
     // don't compare uncached members to new state
     if (before.partial) return;
 

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -8,11 +8,14 @@ import { onVoiceStateUpdate } from './voiceStateUpdate';
 import { onThreadCreate } from './threadCreate';
 import { onThreadDelete } from './threadDelete';
 import { onThreadUpdate } from './threadUpdate';
+import onInteractionCreate from './interactionCreate';
+
 
 export {
     onGuildMemberAdd,
     onGuildMemberUpdate,
     onGuildMemberRemove,
+    onInteractionCreate,
     onMessageCreate,
     onMessageUpdate,
     onMessageDelete,

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,13 +1,13 @@
-import { onGuildMemberUpdate } from './guildMemberUpdate';
-import { onGuildMemberAdd } from './guildMemberAdd';
-import { onGuildMemberRemove } from './guildMemberRemove';
-import { onMessageCreate } from './messageCreate';
-import { onMessageUpdate } from './messageUpdate';
-import { onMessageDelete } from './messageDelete';
-import { onVoiceStateUpdate } from './voiceStateUpdate';
-import { onThreadCreate } from './threadCreate';
-import { onThreadDelete } from './threadDelete';
-import { onThreadUpdate } from './threadUpdate';
+import onGuildMemberUpdate from './guildMemberUpdate';
+import onGuildMemberAdd from './guildMemberAdd';
+import onGuildMemberRemove from './guildMemberRemove';
+import onMessageCreate from './messageCreate';
+import onMessageUpdate from './messageUpdate';
+import onMessageDelete from './messageDelete';
+import onVoiceStateUpdate from './voiceStateUpdate';
+import onThreadCreate from './threadCreate';
+import onThreadDelete from './threadDelete';
+import onThreadUpdate from './threadUpdate';
 import onInteractionCreate from './interactionCreate';
 
 

--- a/src/handlers/interactionCreate.ts
+++ b/src/handlers/interactionCreate.ts
@@ -2,7 +2,7 @@ import { Interaction } from 'discord.js';
 import { listener } from '../commands';
 
 export default async function onInteractionCreate(interaction: Interaction) {
-    if(interaction.isCommand()) {
+    if (interaction.isCommand()) {
         await listener.process(interaction);
     }
 }

--- a/src/handlers/interactionCreate.ts
+++ b/src/handlers/interactionCreate.ts
@@ -1,0 +1,8 @@
+import { Interaction } from 'discord.js';
+import { listener } from '../commands';
+
+export default async function onInteractionCreate(interaction: Interaction) {
+    if(interaction.isCommand()) {
+        await listener.process(interaction);
+    }
+}

--- a/src/handlers/messageCreate.ts
+++ b/src/handlers/messageCreate.ts
@@ -1,6 +1,6 @@
 import { Message } from 'discord.js';
 import AntiSpamModule from '../modules/automod/AntiSpam';
 
-export async function onMessageCreate(message: Message) {
+export default async function onMessageCreate(message: Message) {
     await AntiSpamModule.process(message);
 }

--- a/src/handlers/messageDelete.ts
+++ b/src/handlers/messageDelete.ts
@@ -1,7 +1,7 @@
 import { Message, PartialMessage } from 'discord.js';
 import LoggingModule from '../modules/logging/LoggingModule';
 
-export async function onMessageDelete(message: Message | PartialMessage) {
+export default async function onMessageDelete(message: Message | PartialMessage) {
     if (message.partial) { return; }
 
     await LoggingModule.logMessageDelete(message);

--- a/src/handlers/messageUpdate.ts
+++ b/src/handlers/messageUpdate.ts
@@ -1,7 +1,7 @@
 import { Message, PartialMessage } from 'discord.js';
 import LoggingModule from '../modules/logging/LoggingModule';
 
-export async function onMessageUpdate(before: Message | PartialMessage, after: Message | PartialMessage) {
+export default async function onMessageUpdate(before: Message | PartialMessage, after: Message | PartialMessage) {
     // only track message content updates and non-partial after messages
     if (before.content === after.content || after.partial) { return; }
 

--- a/src/handlers/threadCreate.ts
+++ b/src/handlers/threadCreate.ts
@@ -2,7 +2,7 @@ import { MessageEmbed, ThreadChannel } from 'discord.js';
 import i18next from 'i18next';
 import LoggingModule from '../modules/logging/LoggingModule';
 
-export async function onThreadCreate(thread: ThreadChannel, isNew: boolean) {
+export default async function onThreadCreate(thread: ThreadChannel, isNew: boolean) {
     // threadCreate is emitted for both newly created threads
     // AND when the client is added to a thread
     if (!isNew) { return; }

--- a/src/handlers/threadDelete.ts
+++ b/src/handlers/threadDelete.ts
@@ -2,7 +2,7 @@ import { MessageEmbed, ThreadChannel } from 'discord.js';
 import i18next from 'i18next';
 import LoggingModule from '../modules/logging/LoggingModule';
 
-export async function onThreadDelete(thread: ThreadChannel) {
+export default async function onThreadDelete(thread: ThreadChannel) {
     const channel = await LoggingModule.retrieveLogChannel('threadEvents', thread.guild);
 
     const lng = thread.guild.preferredLocale;

--- a/src/handlers/threadUpdate.ts
+++ b/src/handlers/threadUpdate.ts
@@ -2,7 +2,7 @@ import { MessageEmbed, ThreadChannel } from 'discord.js';
 import i18next from 'i18next';
 import LoggingModule from '../modules/logging/LoggingModule';
 
-export async function onThreadUpdate(before: ThreadChannel, after: ThreadChannel) {
+export default async function onThreadUpdate(before: ThreadChannel, after: ThreadChannel) {
     const channel = await LoggingModule.retrieveLogChannel('threadEvents', after.guild);
 
     const lng = after.guild.preferredLocale;

--- a/src/handlers/voiceStateUpdate.ts
+++ b/src/handlers/voiceStateUpdate.ts
@@ -17,7 +17,7 @@ function getVoiceState(before: VoiceState, after: VoiceState): State {
     }
 }
 
-export async function onVoiceStateUpdate(before: VoiceState, after: VoiceState) {
+export default async function onVoiceStateUpdate(before: VoiceState, after: VoiceState) {
     const logChannel = await LoggingModule.retrieveLogChannel('voiceEvents', after.guild);
     const lng = after.guild.preferredLocale;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,11 +41,15 @@ client.on('threadUpdate', async (before: ThreadChannel, after: ThreadChannel) =>
 // TODO: See above
 client.on('voiceStateUpdate', async (before: VoiceState, after: VoiceState) => await handlers.onVoiceStateUpdate(before, after));
 
-i18next.use(Backend).init({
-    lng: 'en-US',
-    fallbackLng: 'en-US',
-    cleanCode: true,
-    backend: {
-        loadPath: './locales/{{lng}}/translation.json'
-    }
-}).then(() => client.login(config.token));
+(async () => {
+    await i18next.use(Backend).init({
+        lng: 'en-US',
+        fallbackLng: 'en-US',
+        cleanCode: true,
+        backend: {
+            loadPath: './locales/{{lng}}/translation.json'
+        }
+    });
+
+    await client.login(config.token);
+})();

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ client.on('guildMemberRemove', async (member) => await handlers.onGuildMemberRem
 client.on('guildMemberUpdate', async (before: GuildMember | PartialGuildMember, after: GuildMember) =>
     await handlers.onGuildMemberUpdate(before, after));
 
+client.on('interactionCreate', async (interaction) => await handlers.onInteractionCreate(interaction));
+
 client.on('messageCreate', async (message) => await handlers.onMessageCreate(message));
 
 client.on('messageDelete', async (message) => await handlers.onMessageDelete(message));

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ client.on('voiceStateUpdate', async (before: VoiceState, after: VoiceState) => a
     const rest = new REST({ version: '10' }).setToken(token);
     const body = commands.listener.getCommands();
 
-    await rest.put(Routes.applicationCommands(config.clientId), { body: body })
+    await rest.put(Routes.applicationCommands(config.clientId), { body: body });
     console.log(`Updated ${body.length} slash commands`);
 
     // login

--- a/src/modules/logging/LoggingModule.ts
+++ b/src/modules/logging/LoggingModule.ts
@@ -233,7 +233,7 @@ export default class LoggingModule {
     }
 
     static async logMessageDelete(message: Message) {
-        if (message.guild == null || message.content == null) { return; }
+        if (message.guild == null || message.content == '') { return; }
 
         const channel = await this.retrieveLogChannel('messageDeletes', message.guild);
         const lng = message.guild.preferredLocale;

--- a/src/util/commands/CommandListener.ts
+++ b/src/util/commands/CommandListener.ts
@@ -1,4 +1,4 @@
-import SlashCommand from './slash/SlashCommand';
+import { SlashCommand } from './slash';
 import { CommandInteraction } from 'discord.js';
 
 export default class {

--- a/src/util/commands/CommandListener.ts
+++ b/src/util/commands/CommandListener.ts
@@ -5,7 +5,7 @@ export default class {
     private readonly commandMap: Map<string, SlashCommand> = new Map();
 
     constructor(...commands: SlashCommand[]) {
-        for(const command of commands) {
+        for (const command of commands) {
             this.commandMap.set(command.getName(), command);
         }
     }
@@ -13,8 +13,8 @@ export default class {
     getCommands() {
         const data = [];
 
-        for(const [key, value] of this.commandMap) {
-            data.push(value.toJSON());
+        for (const cmd of this.commandMap.values()) {
+            data.push(cmd.toJSON());
         }
 
         return data;

--- a/src/util/commands/CommandListener.ts
+++ b/src/util/commands/CommandListener.ts
@@ -1,0 +1,16 @@
+import SlashCommand from './slash/SlashCommand';
+import { CommandInteraction } from 'discord.js';
+
+export default class {
+    private readonly commandMap: Map<string, SlashCommand> = new Map();
+
+    constructor(...commands: SlashCommand[]) {
+        for(const command of commands) {
+            this.commandMap.set(command.name, command);
+        }
+    }
+
+    async process(interaction: CommandInteraction) {
+        await this.commandMap.get(interaction.commandName)?.process(interaction);
+    }
+}

--- a/src/util/commands/CommandListener.ts
+++ b/src/util/commands/CommandListener.ts
@@ -6,7 +6,7 @@ export default class {
 
     constructor(...commands: SlashCommand[]) {
         for(const command of commands) {
-            this.commandMap.set(command.name, command);
+            this.commandMap.set(command.getName(), command);
         }
     }
 

--- a/src/util/commands/CommandListener.ts
+++ b/src/util/commands/CommandListener.ts
@@ -10,6 +10,16 @@ export default class {
         }
     }
 
+    getCommands() {
+        const data = [];
+
+        for(const [key, value] of this.commandMap) {
+            data.push(value.toJSON());
+        }
+
+        return data;
+    }
+
     async process(interaction: CommandInteraction) {
         await this.commandMap.get(interaction.commandName)?.process(interaction);
     }

--- a/src/util/commands/slash.ts
+++ b/src/util/commands/slash.ts
@@ -1,5 +1,4 @@
 import { SlashCommandBuilder, SlashCommandSubcommandBuilder, SlashCommandSubcommandGroupBuilder } from '@discordjs/builders';
-import { RESTPostAPIApplicationCommandsJSONBody } from 'discord-api-types/v10';
 import { CommandInteraction } from 'discord.js';
 
 abstract class CommandBase<BuilderType extends SlashCommandBuilder | SlashCommandSubcommandBuilder | SlashCommandSubcommandGroupBuilder> {
@@ -34,14 +33,14 @@ export abstract class SlashCommand extends CommandBase<SlashCommandBuilder> {
     }
 
     addSubcommandGroups(...groups: SubcommandGroup[]) {
-        for(const group of groups) {
+        for (const group of groups) {
             this.dataBuilder.addSubcommandGroup(group.getData());
             this.subcommandGroups.set(group.getName(), group);
         }
     }
 
     addSubcommands(...subcommands: Subcommand[]) {
-        for(const command of subcommands) {
+        for (const command of subcommands) {
             this.dataBuilder.addSubcommand(command.getData());
             this.subcommands.set(command.getName(), command);
         }
@@ -63,8 +62,8 @@ export abstract class SlashCommand extends CommandBase<SlashCommandBuilder> {
             if (subcommandGroup == null && subcommand == null) {
                 await this.invoke(interaction);
             }
-            else if(subcommand != null) {
-                await this.subcommands.get(subcommand)?.process(interaction)
+            else if (subcommand != null) {
+                await this.subcommands.get(subcommand)?.process(interaction);
             }
         }
     }
@@ -77,7 +76,7 @@ export abstract class Subcommand extends CommandBase<SlashCommandSubcommandBuild
         super(name, description);
         this.dataBuilder = new SlashCommandSubcommandBuilder()
             .setName(name)
-            .setDescription(description)
+            .setDescription(description);
     }
 
     override getData() {
@@ -85,10 +84,10 @@ export abstract class Subcommand extends CommandBase<SlashCommandSubcommandBuild
     }
 
     override async process(interaction: CommandInteraction) {
-        if(interaction.isCommand()) {
+        if (interaction.isCommand()) {
             const name = interaction.options.getSubcommand();
-            if(name == this.name) {
-                await this.invoke(interaction)
+            if (name == this.name) {
+                await this.invoke(interaction);
             }
         }
     }
@@ -106,7 +105,7 @@ export abstract class SubcommandGroup extends CommandBase<SlashCommandSubcommand
     }
 
     addSubcommands(...subcommands: Subcommand[]) {
-        for(const command of subcommands) {
+        for (const command of subcommands) {
             this.dataBuilder.addSubcommand(command.getData());
             this.subcommands.set(command.getName(), command);
         }
@@ -117,15 +116,16 @@ export abstract class SubcommandGroup extends CommandBase<SlashCommandSubcommand
     }
 
     override async process(interaction: CommandInteraction) {
-        if(interaction.isCommand()) {
+        if (interaction.isCommand()) {
             const name = interaction.options.getSubcommandGroup();
             const subcommandName = interaction.options.getSubcommand();
 
-            if(name == this.name) {
+            if (name == this.name) {
                 await this.subcommands.get(subcommandName)?.process(interaction);
             }
         }
     }
 
-    override async invoke(_: CommandInteraction) {}
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    override async invoke(_: CommandInteraction) { return; }
 }

--- a/src/util/commands/slash.ts
+++ b/src/util/commands/slash.ts
@@ -20,7 +20,7 @@ abstract class CommandBase<BuilderType extends SlashCommandBuilder | SlashComman
 }
 
 export abstract class SlashCommand extends CommandBase<SlashCommandBuilder> {
-    private readonly dataBuilder: SlashCommandBuilder;
+    protected readonly dataBuilder: SlashCommandBuilder;
     private readonly subcommandGroups: Map<string, SubcommandGroup> = new Map();
     private readonly subcommands: Map<string, Subcommand> = new Map();
 
@@ -70,7 +70,7 @@ export abstract class SlashCommand extends CommandBase<SlashCommandBuilder> {
 }
 
 export abstract class Subcommand extends CommandBase<SlashCommandSubcommandBuilder> {
-    private readonly dataBuilder: SlashCommandSubcommandBuilder;
+    protected readonly dataBuilder: SlashCommandSubcommandBuilder;
 
     constructor(name: string, description: string) {
         super(name, description);

--- a/src/util/commands/slash.ts
+++ b/src/util/commands/slash.ts
@@ -33,6 +33,13 @@ export abstract class SlashCommand extends CommandBase<SlashCommandBuilder> {
             .setDescription(description);
     }
 
+    addSubcommands(...subcommands: Subcommand[]) {
+        for(const command of subcommands) {
+            this.dataBuilder.addSubcommand(command.getData());
+            this.subcommands.set(command.getName(), command);
+        }
+    }
+
     override getData() {
         return this.dataBuilder;
     }
@@ -51,6 +58,30 @@ export abstract class SlashCommand extends CommandBase<SlashCommandBuilder> {
             }
             else if(subcommand != null) {
                 await this.subcommands.get(subcommand)?.process(interaction)
+            }
+        }
+    }
+}
+
+export abstract class Subcommand extends CommandBase<SlashCommandSubcommandBuilder> {
+    private readonly dataBuilder: SlashCommandSubcommandBuilder;
+
+    constructor(name: string, description: string) {
+        super(name, description);
+        this.dataBuilder = new SlashCommandSubcommandBuilder()
+            .setName(name)
+            .setDescription(description)
+    }
+
+    override getData() {
+        return this.dataBuilder;
+    }
+
+    override async process(interaction: CommandInteraction) {
+        if(interaction.isCommand()) {
+            const name = interaction.options.getSubcommand();
+            if(name == this.name) {
+                await this.invoke(interaction)
             }
         }
     }

--- a/src/util/commands/slash/SlashCommand.ts
+++ b/src/util/commands/slash/SlashCommand.ts
@@ -36,11 +36,11 @@ export default abstract class extends SlashCommandBase {
     }
 
     override async process(interaction: CommandInteraction) {
-        if (interaction.commandName === this.name) {
+        if (interaction.commandName == this.name) {
             const subcommand = interaction.options.getSubcommand(false);
             const subcommandGroup = interaction.options.getSubcommandGroup(false);
 
-            if (subcommandGroup === null && subcommand == null) {
+            if (subcommandGroup == null && subcommand == null) {
                 await this.invoke(interaction);
             }
         }

--- a/src/util/commands/slash/SlashCommand.ts
+++ b/src/util/commands/slash/SlashCommand.ts
@@ -1,0 +1,38 @@
+import { SlashCommandBuilder } from '@discordjs/builders';
+import { CommandInteraction } from 'discord.js';
+
+export abstract class SlashCommandBase {
+    readonly name: string;
+    readonly description: string;
+
+    constructor(name: string, description: string) {
+        this.name = name;
+        this.description = description;
+    }
+
+    abstract process(interaction: CommandInteraction): Promise<void>
+    abstract invoke(interaction: CommandInteraction): Promise<void>
+}
+
+export default abstract class extends SlashCommandBase {
+    readonly dataBuilder: SlashCommandBuilder;
+
+    constructor(name: string, description: string) {
+        super(name, description);
+
+        this.dataBuilder = new SlashCommandBuilder()
+            .setName(name)
+            .setDescription(description);
+    }
+
+    override async process(interaction: CommandInteraction): Promise<void> {
+        if (interaction.commandName === this.name) {
+            const subcommand = interaction.options.getSubcommand(false);
+            const subcommandGroup = interaction.options.getSubcommandGroup(false);
+
+            if (subcommandGroup === null && subcommand == null) {
+                await this.invoke(interaction);
+            }
+        }
+    }
+}

--- a/src/util/commands/slash/SlashCommand.ts
+++ b/src/util/commands/slash/SlashCommand.ts
@@ -2,12 +2,16 @@ import { SlashCommandBuilder } from '@discordjs/builders';
 import { CommandInteraction } from 'discord.js';
 
 export abstract class SlashCommandBase {
-    readonly name: string;
-    readonly description: string;
+    protected readonly name: string;
+    protected readonly description: string;
 
     constructor(name: string, description: string) {
         this.name = name;
         this.description = description;
+    }
+
+    getName() {
+        return this.name;
     }
 
     abstract process(interaction: CommandInteraction): Promise<void>
@@ -25,7 +29,7 @@ export default abstract class extends SlashCommandBase {
             .setDescription(description);
     }
 
-    override async process(interaction: CommandInteraction): Promise<void> {
+    override async process(interaction: CommandInteraction) {
         if (interaction.commandName === this.name) {
             const subcommand = interaction.options.getSubcommand(false);
             const subcommandGroup = interaction.options.getSubcommandGroup(false);

--- a/src/util/commands/slash/SlashCommand.ts
+++ b/src/util/commands/slash/SlashCommand.ts
@@ -1,4 +1,5 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
+import { RESTPostAPIApplicationCommandsJSONBody } from 'discord-api-types/v10';
 import { CommandInteraction } from 'discord.js';
 
 export abstract class SlashCommandBase {
@@ -16,6 +17,7 @@ export abstract class SlashCommandBase {
 
     abstract process(interaction: CommandInteraction): Promise<void>
     abstract invoke(interaction: CommandInteraction): Promise<void>
+    abstract toJSON(): RESTPostAPIApplicationCommandsJSONBody
 }
 
 export default abstract class extends SlashCommandBase {
@@ -27,6 +29,10 @@ export default abstract class extends SlashCommandBase {
         this.dataBuilder = new SlashCommandBuilder()
             .setName(name)
             .setDescription(description);
+    }
+
+    override toJSON() {
+        return this.dataBuilder.toJSON();
     }
 
     override async process(interaction: CommandInteraction) {


### PR DESCRIPTION
This PR adds support for slash command definitions and handling.

Addresses #19

## Defining Slash Commands
Commands are added by extending from the `SlashCommand` class:
```ts
export default class PingCommand extends SlashCommand {
    constructor() {
        super("ping", "Pong!");
    }

    override async invoke(interaction: CommandInteraction) {
        await interaction.reply({ content: 'Pong!' });
    }
}
```

Then adding them to the listener export of `src/commands/index.ts`:
```ts
const listener = new CommandListener() {
    new PingCommand(),
    // other commands go here
};

export { listener };
```

## Command Caching
A hash of local command data is now cached locally in `warden.commands.cache`. This is used to prevent having to make an API call every login to update command data.

### Known Issues
Updating command options does not cause for warden to update the command through Discord. This can be fixed by setting the content in `warden.commands.cache` to be empty