### PR TITLE
feat[commands]: add commands for configuring mod logs

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -5,6 +5,17 @@
                 "common": {
                     "notSet": "NOT SET"
                 },
+                "set": {
+                    "description": "Set logging channel for `{{- modlogType}}` to {{- value}}",
+                    "fields": {
+                        "before": {
+                            "name": "Before"
+                        },
+                        "after": {
+                            "name": "After"
+                        }
+                    }
+                },
                 "view": {
                     "full": {
                         "title": "Moderation Log Configuration",

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -1,4 +1,23 @@
 {
+    "commands": {
+        "config": {
+            "modlogs": {
+                "view": {
+                    "full": {
+                        "title": "Moderation Log Configuration",
+                        "notSet": "NOT SET",
+                        "footer": "Guild ID: {{guildId}}"
+                    },
+                    "single": {
+                        "description": {
+                            "set": "Logs for `{{- type}}` are currently sent to {{- channelMention}}",
+                            "unset": "There is no channel set for logging {{- type}}"
+                        }
+                    }
+                }
+            }
+        }
+    },
     "logging": {
         "common": {
             "footer": "User ID: {{userId}}"

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -2,10 +2,12 @@
     "commands": {
         "config": {
             "modlogs": {
+                "common": {
+                    "notSet": "NOT SET"
+                },
                 "view": {
                     "full": {
                         "title": "Moderation Log Configuration",
-                        "notSet": "NOT SET",
                         "footer": "Guild ID: {{guildId}}"
                     },
                     "single": {

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -6,7 +6,7 @@
                     "notSet": "NOT SET"
                 },
                 "set": {
-                    "description": "Set logging channel for `{{- modlogType}}` to {{- value}}",
+                    "description": "Set logging channel for `{{- type}}` to {{- value}}",
                     "fields": {
                         "before": {
                             "name": "Before"

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -1,5 +1,6 @@
 import { CommandInteraction, Permissions } from 'discord.js';
 import { SlashCommand } from '../../util/commands/slash';
+import ModlogsGroup from './modlogs';
 
 /**
  * `/config` command - Allows for guild configuration customization.
@@ -10,6 +11,7 @@ export default class ConfigCommand extends SlashCommand {
     constructor() {
         super('config', 'Configuration commands');
         this.dataBuilder.setDefaultMemberPermissions(Permissions.FLAGS.MANAGE_GUILD);
+        this.addSubcommandGroups(new ModlogsGroup());
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -1,9 +1,15 @@
-import { CommandInteraction } from 'discord.js';
+import { CommandInteraction, Permissions } from 'discord.js';
 import { SlashCommand } from '../../util/commands/slash';
 
+/**
+ * `/config` command - Allows for guild configuration customization.
+ *
+ * This requires `MANAGE_GUILD` permissions in order to be used.
+ */
 export default class ConfigCommand extends SlashCommand {
     constructor() {
         super('config', 'Configuration commands');
+        this.dataBuilder.setDefaultMemberPermissions(Permissions.FLAGS.MANAGE_GUILD);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/commands/config/index.ts
+++ b/src/commands/config/index.ts
@@ -1,0 +1,11 @@
+import { CommandInteraction } from 'discord.js';
+import { SlashCommand } from '../../util/commands/slash';
+
+export default class ConfigCommand extends SlashCommand {
+    constructor() {
+        super('config', 'Configuration commands');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    override async invoke(_: CommandInteraction) { return; }
+}

--- a/src/commands/config/modlogs/index.ts
+++ b/src/commands/config/modlogs/index.ts
@@ -1,6 +1,9 @@
+import { LogConfig } from '@prisma/client';
 import { SubcommandGroup } from '../../../util/commands/slash';
 import SetCommand from './set';
 import ViewCommand from './view';
+
+export type LogConfigKeys = keyof Omit<LogConfig, 'guildId'>;
 
 /**
  * `/config modlogs` subcommand - Allows for the configuration of moderation logs.

--- a/src/commands/config/modlogs/index.ts
+++ b/src/commands/config/modlogs/index.ts
@@ -1,0 +1,29 @@
+import { SubcommandGroup } from '../../../util/commands/slash';
+import SetCommand from './set';
+import ViewCommand from './view';
+
+/**
+ * `/config modlogs` subcommand - Allows for the configuration of moderation logs.
+ */
+export default class ModlogsGroup extends SubcommandGroup {
+    static readonly logTypeChoices = [
+        { name: 'Auto-mod Escalations', value: 'escalationsChannelId' },
+        { name: 'Member Joins', value: 'joinsChannelId' },
+        { name: 'Member Leaves', value: 'leavesChannelId' },
+        { name: 'Profile Filter', value: 'userFilterChannelId' },
+        { name: 'Profile Changes', value: 'userChangesChannelId' },
+        { name: 'Text Filter', value: 'textFilterChannelId' },
+        { name: 'Message Deletes', value: 'messageDeletesChannelId' },
+        { name: 'Message Edits', value: 'messageEditsChannelId' },
+        { name: 'Thread Channel Events', value: 'threadEventsChannelId' },
+        { name: 'Voice Chat Events', value: 'voiceEventsChannelId' }
+    ];
+
+    constructor() {
+        super('modlogs', 'Moderation log configuration');
+        this.addSubcommands(
+            new SetCommand(),
+            new ViewCommand()
+        );
+    }
+}

--- a/src/commands/config/modlogs/set.ts
+++ b/src/commands/config/modlogs/set.ts
@@ -1,9 +1,8 @@
 import { CommandInteraction, GuildTextBasedChannel, MessageEmbed } from 'discord.js';
-import ModlogsGroup from '.';
+import ModlogsGroup, { LogConfigKeys } from '.';
 import { Subcommand } from '../../../util/commands/slash';
 import { ChannelType } from 'discord-api-types/v10';
 import LoggingModule, { LogEventType } from '../../../modules/logging/LoggingModule';
-import { LogConfig } from '@prisma/client';
 
 export default class SetCommand extends Subcommand {
     constructor() {
@@ -34,7 +33,7 @@ export default class SetCommand extends Subcommand {
         const content = '';
 
         const config = await LoggingModule.retrieveConfiguration(interaction.guild);
-        const oldChannelId = config[modlogType as keyof LogConfig];
+        const oldChannelId = config[modlogType as LogConfigKeys];
 
         await LoggingModule.setLogChannel(interaction.guild, modlogType.replace('ChannelId', '') as LogEventType, channel);
 

--- a/src/commands/config/modlogs/set.ts
+++ b/src/commands/config/modlogs/set.ts
@@ -3,8 +3,10 @@ import ModlogsGroup, { LogConfigKeys } from '.';
 import { Subcommand } from '../../../util/commands/slash';
 import { ChannelType } from 'discord-api-types/v10';
 import LoggingModule, { LogEventType } from '../../../modules/logging/LoggingModule';
+import i18next from 'i18next';
 
 export default class SetCommand extends Subcommand {
+    // TODO: Localize command data
     constructor() {
         super('set', 'Configure moderation logs');
         this.dataBuilder
@@ -25,6 +27,7 @@ export default class SetCommand extends Subcommand {
     override async invoke(interaction: CommandInteraction) {
         if (interaction.guild == null) { return; }
 
+        const lng = interaction.guild.preferredLocale;
         const opts = interaction.options;
 
         const modlogType = opts.getString('type', true);
@@ -37,17 +40,21 @@ export default class SetCommand extends Subcommand {
 
         await LoggingModule.setLogChannel(interaction.guild, modlogType.replace('ChannelId', '') as LogEventType, channel);
 
-        const NOT_SET = '[NOT SET]';
+        const NOT_SET = i18next.t('commands.config.modlogs.common.notSet');
         const embed = new MessageEmbed()
-            .setDescription(`Set logging channel for \`${modlogType}\` to ${channel?.toString() ?? NOT_SET}`)
+            .setDescription(i18next.t('commands.config.modlogs.set.description', {
+                lng: lng,
+                type: modlogType,
+                value: channel?.toString() ?? NOT_SET
+            }))
             .setColor('BLURPLE')
             .addFields(
                 {
-                    name: 'Before',
+                    name: i18next.t('commands.config.modlogs.set.fields.before.name', { lng: lng }),
                     value: oldChannelId != null ? `<#${oldChannelId}> (id: \`${oldChannelId}\`)` : NOT_SET,
                 },
                 {
-                    name: 'After',
+                    name: i18next.t('commands.config.modlogs.set.fields.after.name', { lng: lng }),
                     value: channel != null ? `${channel.toString()} (id: \`${channel.id}\`)` : NOT_SET
                 }
             );

--- a/src/commands/config/modlogs/set.ts
+++ b/src/commands/config/modlogs/set.ts
@@ -1,0 +1,104 @@
+import { ColorResolvable, CommandInteraction, GuildTextBasedChannel, MessageEmbed } from 'discord.js';
+import ModlogsGroup from '.';
+import { Subcommand } from '../../../util/commands/slash';
+import { ChannelType } from 'discord-api-types/v10';
+import LoggingModule, { LogEventType } from '../../../modules/logging/LoggingModule';
+import { LogConfig } from '@prisma/client';
+
+export default class SetCommand extends Subcommand {
+    constructor() {
+        super('set', 'Configure moderation logs');
+        this.dataBuilder
+            .addStringOption(option => option
+                .setName('type')
+                .setDescription('The type of moderation log to set the configured channel of')
+                .setRequired(true)
+                .addChoices(...ModlogsGroup.logTypeChoices)
+            )
+            .addChannelOption(option => option
+                .setName('channel')
+                .setDescription('The channel to set for the given log type, leave blank to un-set')
+                .setRequired(false)
+                .addChannelTypes(ChannelType.GuildText)
+            );
+    }
+
+    override async invoke(interaction: CommandInteraction) {
+        if (interaction.guild == null) { return; }
+
+        const opts = interaction.options;
+
+        const modlogType = opts.getString('type', true);
+        const channel = opts.getChannel('channel', false) as GuildTextBasedChannel;
+
+        let content = '';
+        let embed: MessageEmbed;
+
+        const config = await LoggingModule.retrieveConfiguration(interaction.guild);
+        if (channel == null) {
+            // display config
+            let description = '';
+            for (const key in config) {
+                if (key == 'guildId') { continue; }
+                const channelId = config[key as keyof LogConfig];
+                const channelMention = channelId != null ? `<#${channelId}>` : '[NOT SET]';
+
+                description = description.concat(`• \`${key}\`: ${channelMention}\n`);
+            }
+
+            if (modlogType == null) {
+                // display entire config
+                embed = new MessageEmbed()
+                    .setTitle('Moderation Log Configuration')
+                    .setDescription(description)
+                    .setColor('BLURPLE')
+                    .setFooter({ text: `Guild ID: ${interaction.guildId}` });
+            }
+            else {
+                // display channel for given type
+                const channelId = config[modlogType as keyof LogConfig];
+                let color: ColorResolvable;
+
+                if (channelId != null) {
+                    description = `Logs for \`${modlogType}\` are currently sent to <#${channelId}>`;
+                    color = 'BLURPLE';
+                    content = channelId;
+                }
+                else {
+                    description = `There is no channel set for logging \`${modlogType}\``;
+                    color = 'RED';
+                }
+
+                embed = new MessageEmbed()
+                    .setDescription(description)
+                    .setColor(color);
+            }
+        }
+        else {
+            // save old channel for feedback message
+            const oldChannelId = config[modlogType as keyof LogConfig];
+
+            // set modlog channel
+            await LoggingModule.setLogChannel(modlogType.replace('ChannelId', '') as LogEventType, channel);
+
+            embed = new MessageEmbed()
+                .setDescription(`Set logging channel for \`${modlogType}\` to ${channel.toString()}`)
+                .addFields(
+                    {
+                        name: 'Before',
+                        value: `<#${oldChannelId}> (id: \`${oldChannelId}\`)`,
+                    },
+                    {
+                        name: 'After',
+                        value: `${channel.toString()} (id: \`${channel.id}\`)`
+                    }
+                );
+        }
+
+        await interaction.reply({
+            content: content != '' ? content : null,
+            embeds: [ embed ]
+        });
+    }
+
+}

--- a/src/commands/config/modlogs/set.ts
+++ b/src/commands/config/modlogs/set.ts
@@ -31,8 +31,7 @@ export default class SetCommand extends Subcommand {
         const modlogType = opts.getString('type', true);
         const channel = opts.getChannel('channel', false) as GuildTextBasedChannel | null;
 
-        let content = '';
-        let embed: MessageEmbed;
+        const content = '';
 
         const config = await LoggingModule.retrieveConfiguration(interaction.guild);
         const oldChannelId = config[modlogType as keyof LogConfig];
@@ -40,7 +39,7 @@ export default class SetCommand extends Subcommand {
         await LoggingModule.setLogChannel(interaction.guild, modlogType.replace('ChannelId', '') as LogEventType, channel);
 
         const NOT_SET = '[NOT SET]';
-        embed = new MessageEmbed()
+        const embed = new MessageEmbed()
             .setDescription(`Set logging channel for \`${modlogType}\` to ${channel?.toString() ?? NOT_SET}`)
             .setColor('BLURPLE')
             .addFields(

--- a/src/commands/config/modlogs/view.ts
+++ b/src/commands/config/modlogs/view.ts
@@ -36,7 +36,7 @@ export default class ViewCommand extends Subcommand {
                 channelMention = `<#${channelId}>`;
             }
             else {
-                channelMention = `[${i18next.t('commands.config.modlogs.view.full.notSet', { lng: lng })}]`;
+                channelMention = `[${i18next.t('commands.config.modlogs.common.notSet', { lng: lng })}]`;
             }
 
             // TODO: still gotta deal with key formatting :shrug: just ignore for now

--- a/src/commands/config/modlogs/view.ts
+++ b/src/commands/config/modlogs/view.ts
@@ -32,8 +32,8 @@ export default class ViewCommand extends Subcommand {
             if (key == 'guildId') { continue; }
             const channelId = config[key as LogConfigKeys];
             let channelMention;
-            if(channelId != null) {
-                channelMention = `<#${channelId}>`
+            if (channelId != null) {
+                channelMention = `<#${channelId}>`;
             }
             else {
                 channelMention = `[${i18next.t('commands.config.modlogs.view.full.notSet', { lng: lng })}]`;
@@ -55,7 +55,7 @@ export default class ViewCommand extends Subcommand {
                 .setFooter({ text: i18next.t('commands.config.modlogs.view.full.footer', {
                     lng: lng,
                     guildId: guild.id
-                })});
+                }) });
         }
         else {
             // display channel for given type

--- a/src/commands/config/modlogs/view.ts
+++ b/src/commands/config/modlogs/view.ts
@@ -11,7 +11,7 @@ export default class ViewCommand extends Subcommand {
             .addStringOption(option => option
                 .setName('type')
                 .setDescription('The type of moderation log event to view the configured channel for')
-                .setRequired(true)
+                .setRequired(false)
                 .addChoices(...ModlogsGroup.logTypeChoices)
             );
     }

--- a/src/commands/config/modlogs/view.ts
+++ b/src/commands/config/modlogs/view.ts
@@ -1,0 +1,72 @@
+import { LogConfig } from '@prisma/client';
+import { ColorResolvable, CommandInteraction, MessageEmbed } from 'discord.js';
+import ModlogsGroup from '.';
+import LoggingModule from '../../../modules/logging/LoggingModule';
+import { Subcommand } from '../../../util/commands/slash';
+
+export default class ViewCommand extends Subcommand {
+    constructor() {
+        super('view', 'View moderation log configuration');
+        this.dataBuilder
+            .addStringOption(option => option
+                .setName('type')
+                .setDescription('The type of moderation log event to view the configured channel for')
+                .setRequired(true)
+                .addChoices(...ModlogsGroup.logTypeChoices)
+            );
+    }
+
+    override async invoke(interaction: CommandInteraction) {
+        if (interaction.guild == null) { return; }
+
+        const modlogType = interaction.options.getString('type');
+
+        let content = '';
+
+        const config = await LoggingModule.retrieveConfiguration(interaction.guild);
+
+        // display config
+        let description = '';
+        for (const key in config) {
+            if (key == 'guildId') { continue; }
+            const channelId = config[key as keyof LogConfig];
+            const channelMention = channelId != null ? `<#${channelId}>` : '[NOT SET]';
+
+            description = description.concat(`• \`${key}\`: ${channelMention}\n`);
+        }
+
+        let embed: MessageEmbed;
+        if (modlogType == null) {
+            // display entire config
+            embed = new MessageEmbed()
+                .setTitle('Moderation Log Configuration')
+                .setDescription(description)
+                .setColor('BLURPLE')
+                .setFooter({ text: `Guild ID: ${interaction.guildId}` });
+        }
+        else {
+            // display channel for given type
+            const channelId = config[modlogType as keyof LogConfig];
+            let color: ColorResolvable;
+
+            if (channelId != null) {
+                description = `Logs for \`${modlogType}\` are currently sent to <#${channelId}>`;
+                color = 'BLURPLE';
+                content = channelId;
+            }
+            else {
+                description = `There is no channel set for logging \`${modlogType}\``;
+                color = 'RED';
+            }
+
+            embed = new MessageEmbed()
+                .setDescription(description)
+                .setColor(color);
+        }
+
+        await interaction.reply({
+            content: content != '' ? content : null,
+            embeds: [ embed ]
+        });
+    }
+}

--- a/src/commands/config/modlogs/view.ts
+++ b/src/commands/config/modlogs/view.ts
@@ -1,6 +1,5 @@
-import { LogConfig } from '@prisma/client';
 import { ColorResolvable, CommandInteraction, MessageEmbed } from 'discord.js';
-import ModlogsGroup from '.';
+import ModlogsGroup, { LogConfigKeys } from '.';
 import LoggingModule from '../../../modules/logging/LoggingModule';
 import { Subcommand } from '../../../util/commands/slash';
 
@@ -19,17 +18,15 @@ export default class ViewCommand extends Subcommand {
     override async invoke(interaction: CommandInteraction) {
         if (interaction.guild == null) { return; }
 
-        const modlogType = interaction.options.getString('type');
-
-        let content = '';
+        const modlogType = interaction.options.getString('type') as LogConfigKeys;
 
         const config = await LoggingModule.retrieveConfiguration(interaction.guild);
 
-        // display config
+        let content = '';
         let description = '';
         for (const key in config) {
             if (key == 'guildId') { continue; }
-            const channelId = config[key as keyof LogConfig];
+            const channelId = config[key as LogConfigKeys];
             const channelMention = channelId != null ? `<#${channelId}>` : '[NOT SET]';
 
             description = description.concat(`• \`${key}\`: ${channelMention}\n`);
@@ -46,7 +43,7 @@ export default class ViewCommand extends Subcommand {
         }
         else {
             // display channel for given type
-            const channelId = config[modlogType as keyof LogConfig];
+            const channelId = config[modlogType];
             let color: ColorResolvable;
 
             if (channelId != null) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,8 @@
 import CommandListener from '../util/commands/CommandListener';
+import ConfigCommand from './config';
 
-const listener = new CommandListener();
+const listener = new CommandListener(
+    new ConfigCommand()
+);
 
 export { listener };

--- a/src/modules/logging/LoggingModule.ts
+++ b/src/modules/logging/LoggingModule.ts
@@ -77,20 +77,22 @@ export default class LoggingModule {
      * Configures a guild's log channel for a particular event type.
      * This operation is write-back, meaning this first updates the cache entry (if cached, see below) followed by the database entry.
      * This operation will automatically cache the given configuration by default unless stated otherwise.
+     * @param guild The guild to modify the configuration of
      * @param event The event type to set the channel for
-     * @param channel The channel to use for logging the aformentioned event
+     * @param channel The channel to use for logging the aformentioned event, or `null` to un-set
      */
-    static async setLogChannel(event: LogEventType, channel: GuildTextBasedChannel) {
-        const guildId = channel.guildId;
-        const key = event + 'ChannelId' as keyof LogConfig;
+    static async setLogChannel(guild: Guild, event: LogEventType, channel: GuildTextBasedChannel | null) {
+        const guildId = guild.id;
+        const key = event + 'ChannelId' as keyof Omit<LogConfig, 'guildId'>;
+        const newValue = channel?.id ?? null;
 
-        const config = await this.retrieveConfiguration(channel.guild);
-        config[key] = channel.id;
+        const config = await this.retrieveConfiguration(guild);
+        config[key] = newValue;
         this.configCache.set(guildId, config);
 
         // a bit cursed, but gets the job done :shrug:
         const update = <LogConfig>{};
-        update[key] = channel.id;
+        update[key] = newValue;
         const create = update;
         create['guildId'] = guildId;
 

--- a/src/modules/logging/LoggingModule.ts
+++ b/src/modules/logging/LoggingModule.ts
@@ -84,7 +84,7 @@ export default class LoggingModule {
         const guildId = channel.guildId;
         const key = event + 'ChannelId' as keyof LogConfig;
 
-        let config = await this.retrieveConfiguration(channel.guild);
+        const config = await this.retrieveConfiguration(channel.guild);
         config[key] = channel.id;
         this.configCache.set(guildId, config);
 

--- a/src/modules/logging/LoggingModule.ts
+++ b/src/modules/logging/LoggingModule.ts
@@ -34,8 +34,9 @@ export default class LoggingModule {
 
     /**
      * Fetches a guild's logging configuration.
+     * If the configuration is cached, this will return the cached entry and not query the database.
      *
-     * This will create a new blank configuration in the event that the config is not found.
+     * This will create a new blank configuration and return the blank entry in the event that the config is not found.
      * @param guild The guild to fetch the config of
      * @returns The configuration
      */
@@ -51,7 +52,8 @@ export default class LoggingModule {
     }
 
     /**
-     * Fetches a guild's log TextChannel of a given event type
+     * Fetches a guild's log TextChannel of a given event type.
+     * If the configuration is cached, this will return the cached entry and not query the database.
      * @param event The type of log event to fetch the log channel of
      * @param guild The guild to fetch the log channel from
      * @returns The TextChannel if it exists, else null

--- a/src/util/commands/slash.ts
+++ b/src/util/commands/slash.ts
@@ -62,13 +62,11 @@ export abstract class SlashCommand extends CommandBase<SlashCommandBuilder> {
             if (subcommandGroup == null && subcommand == null) {
                 await this.invoke(interaction);
             }
-            else {
-                if(subcommandGroup == null && subcommand != null) {
-                    await this.subcommands.get(subcommand)?.process(interaction);
-                }
-                else if(subcommandGroup != null){
-                    await this.subcommandGroups.get(subcommandGroup)?.process(interaction);
-                }
+            else if (subcommandGroup == null && subcommand != null) {
+                await this.subcommands.get(subcommand)?.process(interaction);
+            }
+            else if (subcommandGroup != null) {
+                await this.subcommandGroups.get(subcommandGroup)?.process(interaction);
             }
 
         }

--- a/src/util/commands/slash.ts
+++ b/src/util/commands/slash.ts
@@ -62,9 +62,15 @@ export abstract class SlashCommand extends CommandBase<SlashCommandBuilder> {
             if (subcommandGroup == null && subcommand == null) {
                 await this.invoke(interaction);
             }
-            else if (subcommand != null) {
-                await this.subcommands.get(subcommand)?.process(interaction);
+            else {
+                if(subcommandGroup == null && subcommand != null) {
+                    await this.subcommands.get(subcommand)?.process(interaction);
+                }
+                else if(subcommandGroup != null){
+                    await this.subcommandGroups.get(subcommandGroup)?.process(interaction);
+                }
             }
+
         }
     }
 }


### PR DESCRIPTION
# New Command: '/config modlogs'
This PR adds a new command `/config`. `/config` has one subcommand group `modlogs`, which contain commands for a user to manage their server's moderation logs.

Addresses #19 

## Required Permissions
By default, the `/config` command requires `Manage Server` permissions. Those without this permission will be unable to invoke this command or its subcommands.

## Subcommands
`/config modlogs` has two subcommands: `set` and `view`

### Set
`/config modlogs set` allows for a user to assign a channel to receive logs for a particular moderation event

Parameters:
| Name | Type | Required? | Description |
| --- | --- | --- | --- |
| `type` | Choice | Yes | The modlog type the user wishes to assign |
| `channel` | Channel (Text) | No | The channel to assign the log type to. Leave blank to un-set |

### View
`/config modlogs view` allows for a user to view the server's moderation logging configuration

Parameters:
| Name | Type | Required? | Description |
| --- | --- | --- | --- |
| `type` | Choice | No | The modlog type the user wishes to view the assigned channel of. Leave blank to view the whole configuration |