### PR TITLE
fix[logging]: improper role change logs formatting

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -172,6 +172,13 @@
                 }
             },
             "roles": {
+                "common": {
+                    "fields": {
+                        "roles": {
+                            "name": "Roles"
+                        }
+                    }
+                },
                 "add": {
                     "single": {
                         "title": "Role Added",
@@ -183,13 +190,6 @@
                     }
                 },
                 "remove": {
-                    "common": {
-                        "fields": {
-                            "roles": {
-                                "name": "Roles"
-                            }
-                        }
-                    },
                     "single": {
                         "title": "Role Removed",
                         "description": "{{- userMention}} had a role removed"

--- a/src/handlers/guildMemberUpdate.ts
+++ b/src/handlers/guildMemberUpdate.ts
@@ -30,11 +30,12 @@ function getRoleUpdateEmbed(member: GuildMember, roles: Collection<string, Role>
 
     // TODO: i18next has a way of handling plurals for us instead
     const count = roles.size;
+    const mention = user.toString();
     if (count == 1) {
         title = i18next.t(`logging.userChanges.roles.${action}.single.title`, { lng: lng });
         description = i18next.t(`logging.userChanges.roles.${action}.single.description`, {
             lng: lng,
-            userMention: user.toString()
+            userMention: mention
         });
     }
     else {
@@ -44,6 +45,7 @@ function getRoleUpdateEmbed(member: GuildMember, roles: Collection<string, Role>
         });
         description = i18next.t(`logging.userChanges.roles.${action}.multi.description`, {
             lng: lng,
+            userMention: mention,
             count: count
         });
     }


### PR DESCRIPTION
Fixed improper translation key for role change log field `Roles` and missing user mention.

Closes #30