### PR TITLE
fix: misc logs

### DIFF
--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -118,7 +118,7 @@
                 "footer": "User ID: {{userId}}\nMessage ID: {{messageId}}",
                 "fields": {
                     "message": {
-                        "name": "message"
+                        "name": "Message"
                     }
                 }
             }

--- a/src/handlers/voiceStateUpdate.ts
+++ b/src/handlers/voiceStateUpdate.ts
@@ -49,6 +49,9 @@ export default async function onVoiceStateUpdate(before: VoiceState, after: Voic
         const from = before.channel;
         const to = after.channel;
 
+        // ensure `from` and `to` aren't the same channel (#32)
+        if (from != null && from.id == after.id) return;
+
         embed = getEmbedWithTarget(member.user, lng)
             .setTitle(i18next.t('logging.voiceEvents.moves.title', { lng: lng }))
             .setDescription(i18next.t('logging.voiceEvents.moves.description', {


### PR DESCRIPTION
This PR fixes the following issues:
- Improper capitalization for the `Message` field in message delete logs
- Voice Change logs sometimes have the before and after channels set to be the same channel.

Closes #32, closes #33